### PR TITLE
fix(cd): add SymbolPackageFormat=snupkg and safe glob for release assets

### DIFF
--- a/.actrc
+++ b/.actrc
@@ -1,0 +1,11 @@
+# act configuration for local workflow testing.
+# See: https://nektosact.com/usage/index.html
+
+# Use full Ubuntu image (has dotnet, node, bun, gh CLI pre-installed)
+-P ubuntu-latest=catthehacker/ubuntu:full-latest
+
+# Load secrets from local .secrets file (never commit this file)
+--secret-file .secrets
+
+# Load env vars for act-specific overrides
+--env-file .env.act

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -142,15 +142,18 @@ jobs:
             PRERELEASE_FLAG="--prerelease"
           fi
 
-          # Create as draft first — draft releases are never immutable, so assets
-          # can be freely attached. The release becomes immutable only after --draft=false.
+          # *.nupkg matches both the main package and *.symbols.nupkg.
+          # nullglob prevents failures if either pattern matches nothing.
+          shopt -s nullglob
+          ASSETS=( ./artifacts/nuget/*.nupkg )
+          shopt -u nullglob
+
           gh release create "${RELEASE_TAG}" \
             --draft \
             --title "${RELEASE_TAG}" \
             --generate-notes \
             ${PRERELEASE_FLAG} \
-            ./artifacts/nuget/*.nupkg \
-            ./artifacts/nuget/*.snupkg
+            "${ASSETS[@]}"
 
           # Publish: marks as latest and becomes immutable. Any retry will clean up above.
           gh release edit "${RELEASE_TAG}" \

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -142,11 +142,22 @@ jobs:
             PRERELEASE_FLAG="--prerelease"
           fi
 
-          # *.nupkg matches both the main package and *.symbols.nupkg.
-          # nullglob prevents failures if either pattern matches nothing.
+          # Collect assets safely and fail if no package output exists.
           shopt -s nullglob
-          ASSETS=( ./artifacts/nuget/*.nupkg )
+          PACKAGES=( ./artifacts/nuget/*.nupkg )
+          SYMBOLS=( ./artifacts/nuget/*.snupkg )
           shopt -u nullglob
+
+          if (( ${#PACKAGES[@]} == 0 )); then
+            echo "::error::No .nupkg package assets found in ./artifacts/nuget."
+            exit 1
+          fi
+
+          if (( ${#SYMBOLS[@]} == 0 )); then
+            echo "::warning::No .snupkg symbol assets found in ./artifacts/nuget."
+          fi
+
+          ASSETS=( "${PACKAGES[@]}" "${SYMBOLS[@]}" )
 
           gh release create "${RELEASE_TAG}" \
             --draft \

--- a/.gitignore
+++ b/.gitignore
@@ -197,3 +197,7 @@ node_modules/
 
 # BenchmarkDotNet output
 BenchmarkDotNet.Artifacts/!scripts/*
+
+# act local secrets
+.secrets
+.env.act

--- a/.secrets.template
+++ b/.secrets.template
@@ -1,0 +1,3 @@
+# Template — copy to .secrets (gitignored) and fill in values.
+# Used by act for local workflow testing.
+GITHUB_TOKEN=<your-pat-with-contents:write-and-packages:write>


### PR DESCRIPTION
## Problem

The \Publish GitHub Release\ step failed with:
\
o matches found for ./artifacts/nuget/*.snupkg\

\dotnet pack --include-symbols\ without \/p:SymbolPackageFormat=snupkg\ generates \*.symbols.nupkg\, not \*.snupkg\. The bash glob fails hard under \set -euo pipefail\.

## Fixes

- Add \/p:SymbolPackageFormat=snupkg\ to the pack command so \.snupkg\ files are actually produced
- Use \shopt -s nullglob\ to safely collect assets so the release create never fails on an empty glob